### PR TITLE
chore: update rmcp v1.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4789,9 +4789,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4950422f87cf98fffc36946ad672c3024750b3c301491599715b7d6497dfbc"
+checksum = "ba6b9d2f0efe2258b23767f1f9e0054cfbcac9c2d6f81a031214143096d7864f"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4821,9 +4821,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f9a2cbdcc704fa56c3fe79c681bd8f739d77c68ede3a670faeb6df50f836874"
+checksum = "ab9d95d7ed26ad8306352b0d5f05b593222b272790564589790d210aa15caa9e"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ axum = { version = "0.8", features = ["macros"] }
 chrono = "0.4"
 openid = "0.18.0"
 reqwest = { version = "0.12", features = ["json", "blocking"] }
-rmcp = { version = "1.1.1", features = ["server", "transport-io", "transport-streamable-http-server"] }
+rmcp = { version = "1.2.0", features = ["server", "transport-io", "transport-streamable-http-server"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "io-std", "signal"] }
@@ -33,6 +33,6 @@ urlencoding = "2.1"
 
 [dev-dependencies]
 log = "0.4"
-rmcp = { version = "1.1.1", features = ["client", "transport-child-process"] }
+rmcp = { version = "1.2.0", features = ["client", "transport-child-process"] }
 test-log = "0.2.18"
 trustify-test-context = { git = "https://github.com/guacsec/trustify.git", tag = "v0.4.5"}


### PR DESCRIPTION
## Summary by Sourcery

Update rmcp dependency to version 1.2.0 for both main and dev builds.

Build:
- Bump rmcp crate from 1.1.1 to 1.2.0 in main dependencies.
- Bump rmcp crate from 1.1.1 to 1.2.0 in dev-dependencies.