### PR TITLE
chore: update rmcp v1.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4789,9 +4789,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba6b9d2f0efe2258b23767f1f9e0054cfbcac9c2d6f81a031214143096d7864f"
+checksum = "2231b2c085b371c01bc90c0e6c1cab8834711b6394533375bdbf870b0166d419"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4821,9 +4821,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab9d95d7ed26ad8306352b0d5f05b593222b272790564589790d210aa15caa9e"
+checksum = "36ea0e100fadf81be85d7ff70f86cd805c7572601d4ab2946207f36540854b43"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ axum = { version = "0.8", features = ["macros"] }
 chrono = "0.4"
 openid = "0.18.0"
 reqwest = { version = "0.12", features = ["json", "blocking"] }
-rmcp = { version = "1.2.0", features = ["server", "transport-io", "transport-streamable-http-server"] }
+rmcp = { version = "1.3.0", features = ["server", "transport-io", "transport-streamable-http-server"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "io-std", "signal"] }
@@ -33,6 +33,6 @@ urlencoding = "2.1"
 
 [dev-dependencies]
 log = "0.4"
-rmcp = { version = "1.2.0", features = ["client", "transport-child-process"] }
+rmcp = { version = "1.3.0", features = ["client", "transport-child-process"] }
 test-log = "0.2.18"
 trustify-test-context = { git = "https://github.com/guacsec/trustify.git", tag = "v0.4.5"}


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Bump rmcp crate from 1.2.0 to 1.3.0 in main dependencies and dev-dependencies.