### PR TITLE
chore: update rmcp v1.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4789,9 +4789,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2231b2c085b371c01bc90c0e6c1cab8834711b6394533375bdbf870b0166d419"
+checksum = "f542f74cf247da16f19bbc87e298cd201e912314f4083e88cdd671f44f5fcb53"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4821,9 +4821,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36ea0e100fadf81be85d7ff70f86cd805c7572601d4ab2946207f36540854b43"
+checksum = "b2391e4ae47f314e70eaafb6c7bd82e495e770b935448864446302143019151f"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ axum = { version = "0.8", features = ["macros"] }
 chrono = "0.4"
 openid = "0.18.0"
 reqwest = { version = "0.12", features = ["json", "blocking"] }
-rmcp = { version = "1.3.0", features = ["server", "transport-io", "transport-streamable-http-server"] }
+rmcp = { version = "1.4.0", features = ["server", "transport-io", "transport-streamable-http-server"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "io-std", "signal"] }
@@ -33,6 +33,6 @@ urlencoding = "2.1"
 
 [dev-dependencies]
 log = "0.4"
-rmcp = { version = "1.3.0", features = ["client", "transport-child-process"] }
+rmcp = { version = "1.4.0", features = ["client", "transport-child-process"] }
 test-log = "0.2.18"
 trustify-test-context = { git = "https://github.com/guacsec/trustify.git", tag = "v0.4.5"}

--- a/src/bin/common/trustify.rs
+++ b/src/bin/common/trustify.rs
@@ -6,7 +6,6 @@ use crate::common::trustify_requests::{
 use reqwest::blocking::{Client, RequestBuilder, Response};
 use rmcp::{
     ErrorData, ServerHandler,
-    handler::server::tool::ToolRouter,
     handler::server::wrapper::Parameters,
     model::{
         CallToolResult, Content, Implementation, ProtocolVersion, ServerCapabilities, ServerInfo,
@@ -22,7 +21,6 @@ use trustify_module_fundamental::vulnerability::model::VulnerabilityDetails;
 
 #[derive(Clone)]
 pub struct Trustify {
-    tool_router: ToolRouter<Self>,
     http_client: Client,
     api_base_url: String,
     openid_issuer_url: String,
@@ -49,7 +47,6 @@ impl Trustify {
             .expect("Failed to create HTTP client");
 
         Self {
-            tool_router: Self::tool_router(),
             http_client,
             api_base_url,
             openid_issuer_url,


### PR DESCRIPTION
## Summary by Sourcery

Update rmcp dependency to v1.4.0 and remove an unused ToolRouter field from the Trustify binary.

Enhancements:
- Bump rmcp crate to version 1.4.0 for both main and dev dependencies.
- Simplify the Trustify struct by removing an unused ToolRouter field.