### PR TITLE
chore: update rmcp v1.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4789,9 +4789,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f542f74cf247da16f19bbc87e298cd201e912314f4083e88cdd671f44f5fcb53"
+checksum = "67d69668de0b0ccd9cc435f700f3b39a7861863cf37a15e1f304ea78688a4826"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4821,9 +4821,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2391e4ae47f314e70eaafb6c7bd82e495e770b935448864446302143019151f"
+checksum = "48fdc01c81097b0aed18633e676e269fefa3a78ec1df56b4fe597c1241b92025"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ axum = { version = "0.8", features = ["macros"] }
 chrono = "0.4"
 openid = "0.18.0"
 reqwest = { version = "0.12", features = ["json", "blocking"] }
-rmcp = { version = "1.4.0", features = ["server", "transport-io", "transport-streamable-http-server"] }
+rmcp = { version = "1.5.0", features = ["server", "transport-io", "transport-streamable-http-server"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "io-std", "signal"] }
@@ -33,6 +33,6 @@ urlencoding = "2.1"
 
 [dev-dependencies]
 log = "0.4"
-rmcp = { version = "1.4.0", features = ["client", "transport-child-process"] }
+rmcp = { version = "1.5.0", features = ["client", "transport-child-process"] }
 test-log = "0.2.18"
 trustify-test-context = { git = "https://github.com/guacsec/trustify.git", tag = "v0.4.5"}


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Bump rmcp dependency from 1.4.0 to 1.5.0 in main dependencies and dev-dependencies.