### PR TITLE
feat: add Codecov integration with cargo-llvm-cov

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,8 @@ env:
 jobs:
   ci:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - name: Maximize build space
         run: |
@@ -34,5 +36,17 @@ jobs:
         run: cargo fmt --check
       - name: Check
         run: cargo check
-      - name: Test
-        run: cargo test -r
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+      - name: Install llvm-tools-preview
+        run: rustup component add llvm-tools-preview
+      - name: Test with coverage
+        run: cargo llvm-cov --codecov --output-path codecov.json
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          use_oidc: true
+          flags: unit-tests
+          files: codecov.json
+          slug: guacsec/trustify-mcp

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,17 +36,18 @@ jobs:
         run: cargo fmt --check
       - name: Check
         run: cargo check
+      - name: Test
+        run: cargo test -r
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-llvm-cov
       - name: Install llvm-tools-preview
         run: rustup component add llvm-tools-preview
-      - name: Test with coverage
-        run: cargo llvm-cov --codecov --output-path codecov.json
+      - name: Generate coverage
+        run: cargo llvm-cov --lib --codecov --output-path codecov.json
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
           use_oidc: true
           flags: unit-tests
           files: codecov.json
-          slug: guacsec/trustify-mcp

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,20 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+
+flags:
+  unit-tests:
+    carryforward: true
+
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default


### PR DESCRIPTION
## Summary

- Add **cargo-llvm-cov** for Rust coverage report generation (same tooling as main trustify repo)
- Replace `cargo test -r` with `cargo llvm-cov --codecov` to generate Codecov-format output
- Add **Codecov upload** step using OIDC authentication (no secret needed)
- Add `codecov.yml` with informational status checks, `unit-tests` flag with carryforward

## Changes

| File | Change |
|------|--------|
| `.github/workflows/ci.yaml` | Add `permissions: id-token: write`, install cargo-llvm-cov + llvm-tools-preview, replace test step with coverage, add Codecov upload |
| `codecov.yml` | Coverage config: informational checks, flag setup |

## Manual follow-up

After merging:
1. Go to https://app.codecov.io/gh/guacsec/trustify-mcp
2. Click the **Flags** tab → **Enable flag analytics**

Ref: [COVERPORT-256](https://redhat.atlassian.net/browse/COVERPORT-256)

[COVERPORT-256]: https://redhat.atlassian.net/browse/COVERPORT-256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Integrate Rust coverage reporting into CI and upload results to Codecov using OIDC-based authentication.

Build:
- Add installation of cargo-llvm-cov and llvm-tools-preview to the CI build steps.

CI:
- Update CI workflow to run tests with cargo-llvm-cov instead of cargo test and upload coverage reports to Codecov using OIDC.

Tests:
- Switch Rust test execution in CI to coverage-enabled runs that generate Codecov-compatible reports.

Chores:
- Add Codecov configuration for informational coverage and patch status checks with unit-test flag carryforward.