### PR TITLE
chore: update rmcp v2.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4789,9 +4789,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.8.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1f571c72940a19d9532fe52dbea8bc9912bf1d766c2970bb824056b86f3f59"
+checksum = "d52d21e5b342699bc4de690e6104fc4e43255e4e8420ff0f2cbb963aac09da6f"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4821,9 +4821,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.8.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aad0035b69380782d78ea95b508327e6deaa2235909053e596eea8f27b5e1d5"
+checksum = "6c68cec74c5b3ac73ff46375ae49e161637bda80bba70f0d5db641583bb308ee"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ axum = { version = "0.8", features = ["macros"] }
 chrono = "0.4"
 openid = "0.18.0"
 reqwest = { version = "0.12", features = ["json", "blocking"] }
-rmcp = { version = "1.8.0", features = ["server", "transport-io", "transport-streamable-http-server"] }
+rmcp = { version = "2.0.0", features = ["server", "transport-io", "transport-streamable-http-server"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "io-std", "signal"] }
@@ -33,6 +33,6 @@ urlencoding = "2.1"
 
 [dev-dependencies]
 log = "0.4"
-rmcp = { version = "1.8.0", features = ["client", "transport-child-process"] }
+rmcp = { version = "2.0.0", features = ["client", "transport-child-process"] }
 test-log = "0.2.18"
 trustify-test-context = { git = "https://github.com/guacsec/trustify.git", tag = "v0.4.5"}

--- a/src/bin/common/trustify.rs
+++ b/src/bin/common/trustify.rs
@@ -8,7 +8,8 @@ use rmcp::{
     ErrorData, ServerHandler,
     handler::server::wrapper::Parameters,
     model::{
-        CallToolResult, Content, Implementation, ProtocolVersion, ServerCapabilities, ServerInfo,
+        CallToolResult, ContentBlock, Implementation, ProtocolVersion, ServerCapabilities,
+        ServerInfo,
     },
     tool, tool_handler, tool_router,
 };
@@ -219,7 +220,7 @@ impl Trustify {
             })
         }
 
-        Ok(CallToolResult::success(vec![Content::json(
+        Ok(CallToolResult::success(vec![ContentBlock::json(
             vulnerability_details,
         )?]))
 
@@ -234,7 +235,7 @@ impl Trustify {
         //     }
         //     response.insert(purl.as_str(), cves);
         // }
-        // Ok(CallToolResult::success(vec![Content::json(response)?]))
+        // Ok(CallToolResult::success(vec![ContentBlock::json(response)?]))
     }
 
     #[tool(description = "Get the details of a vulnerability from a trustify instance by CVE ID")]
@@ -280,7 +281,7 @@ impl Trustify {
         &self,
         Parameters(param): Parameters<UrlEncodeRequest>,
     ) -> Result<CallToolResult, ErrorData> {
-        Ok(CallToolResult::success(vec![Content::text(
+        Ok(CallToolResult::success(vec![ContentBlock::text(
             urlencoding::encode(param.input.as_str()),
         )]))
     }
@@ -313,7 +314,9 @@ impl Trustify {
             }
         };
 
-        Ok(CallToolResult::success(vec![Content::json(response_json)?]))
+        Ok(CallToolResult::success(vec![ContentBlock::json(
+            response_json,
+        )?]))
     }
 
     async fn post_raw<T: Serialize + ?Sized>(


### PR DESCRIPTION
## Summary by Sourcery

Update rmcp dependency to version 2.0.0 and align trustify tooling responses with the new rmcp content API.

Enhancements:
- Switch trustify tool response generation from Content to ContentBlock to match the updated rmcp data model.

Build:
- Bump rmcp crate (runtime and dev dependencies) from 1.8.0 to 2.0.0 with existing server and client transport features.