### PR TITLE
chore: update rmcp v3.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -985,6 +985,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
+
+[[package]]
 name = "base64-simd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4789,12 +4795,12 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "2.2.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14db48ee17a9ba61810ab1a9c1beb7d06d8136ae39ac25a1137f10d357af01af"
+checksum = "fcd2b6dd3b18129368955f32661a7718969e8c152c7d8866434c09cf15a512e0"
 dependencies = [
  "async-trait",
- "base64 0.22.1",
+ "base64 0.23.0",
  "bytes",
  "chrono",
  "futures",
@@ -4821,9 +4827,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "2.2.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "783d787bf21813b285f13019adc49e11af501c658890c1e519f31f937c68b7e3"
+checksum = "e1aa4b9345795260a43fc23d6d05e096407c8b953903f673af7c4404b49fb2d6"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -5999,9 +6005,9 @@ dependencies = [
 
 [[package]]
 name = "sse-stream"
-version = "0.2.1"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb4dc4d33c68ec1f27d386b5610a351922656e1fdf5c05bbaad930cd1519479a"
+checksum = "c123f296ade4ec4b8b0f6162116e6629f5146922ca5ab40ca9d3c2e73ab4761e"
 dependencies = [
  "bytes",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ axum = { version = "0.8", features = ["macros"] }
 chrono = "0.4"
 openid = "0.18.0"
 reqwest = { version = "0.12", features = ["json", "blocking"] }
-rmcp = { version = "2.2.0", features = ["server", "transport-io", "transport-streamable-http-server"] }
+rmcp = { version = "3.0.0", features = ["server", "transport-io", "transport-streamable-http-server"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "io-std", "signal"] }
@@ -33,6 +33,6 @@ urlencoding = "2.1"
 
 [dev-dependencies]
 log = "0.4"
-rmcp = { version = "2.2.0", features = ["client", "transport-child-process"] }
+rmcp = { version = "3.0.0", features = ["client", "transport-child-process"] }
 test-log = "0.2.18"
 trustify-test-context = { git = "https://github.com/guacsec/trustify.git", tag = "v0.4.5"}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -42,8 +42,7 @@ const EXPECTED_TOOLS_LIST_RESPONSE: &str = r#"{
         "required": [
           "advisory_uri"
         ],
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
-        "title": "AdvisoryUriRequest"
+        "$schema": "https://json-schema.org/draft/2020-12/schema"
       }
     },
     {
@@ -63,8 +62,7 @@ const EXPECTED_TOOLS_LIST_RESPONSE: &str = r#"{
         "required": [
           "purls"
         ],
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
-        "title": "VulnerabilitiesForMultiplePurlsRequest"
+        "$schema": "https://json-schema.org/draft/2020-12/schema"
       }
     },
     {
@@ -81,8 +79,7 @@ const EXPECTED_TOOLS_LIST_RESPONSE: &str = r#"{
         "required": [
           "input"
         ],
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
-        "title": "UrlEncodeRequest"
+        "$schema": "https://json-schema.org/draft/2020-12/schema"
       }
     },
     {
@@ -99,8 +96,7 @@ const EXPECTED_TOOLS_LIST_RESPONSE: &str = r#"{
         "required": [
           "sbom_uri"
         ],
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
-        "title": "SbomUriRequest"
+        "$schema": "https://json-schema.org/draft/2020-12/schema"
       }
     },
     {
@@ -124,8 +120,7 @@ const EXPECTED_TOOLS_LIST_RESPONSE: &str = r#"{
           "query",
           "limit"
         ],
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
-        "title": "SbomListRequest"
+        "$schema": "https://json-schema.org/draft/2020-12/schema"
       }
     },
     {
@@ -142,8 +137,7 @@ const EXPECTED_TOOLS_LIST_RESPONSE: &str = r#"{
         "required": [
           "cve_id"
         ],
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
-        "title": "VulnerabilityDetailsRequest"
+        "$schema": "https://json-schema.org/draft/2020-12/schema"
       }
     },
     {
@@ -160,8 +154,7 @@ const EXPECTED_TOOLS_LIST_RESPONSE: &str = r#"{
         "required": [
           "sbom_uri"
         ],
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
-        "title": "SbomUriRequest"
+        "$schema": "https://json-schema.org/draft/2020-12/schema"
       }
     },
     {
@@ -178,8 +171,7 @@ const EXPECTED_TOOLS_LIST_RESPONSE: &str = r#"{
         "required": [
           "sbom_uri"
         ],
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
-        "title": "SbomUriRequest"
+        "$schema": "https://json-schema.org/draft/2020-12/schema"
       }
     },
     {
@@ -231,8 +223,7 @@ const EXPECTED_TOOLS_LIST_RESPONSE: &str = r#"{
           "sort_field",
           "sort_direction"
         ],
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
-        "title": "VulnerabilitiesListRequest"
+        "$schema": "https://json-schema.org/draft/2020-12/schema"
       }
     },
     {
@@ -249,8 +240,7 @@ const EXPECTED_TOOLS_LIST_RESPONSE: &str = r#"{
         "required": [
           "package_uri_or_purl"
         ],
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
-        "title": "PurlVulnerabilitiesRequest"
+        "$schema": "https://json-schema.org/draft/2020-12/schema"
       }
     },
     {
@@ -279,8 +269,7 @@ const EXPECTED_TOOLS_LIST_RESPONSE: &str = r#"{
           "limit",
           "sort"
         ],
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
-        "title": "AdvisoryListRequest"
+        "$schema": "https://json-schema.org/draft/2020-12/schema"
       }
     }
   ]
@@ -289,17 +278,13 @@ const EXPECTED_TOOLS_LIST_RESPONSE: &str = r#"{
 #[test]
 fn tools_list_mcp_inspector_stdio() {
     let inspector_commmand = format!(
-        "npx @modelcontextprotocol/inspector --cli {} --method tools/list",
+        "npx @modelcontextprotocol/inspector --cli {} -e API_URL=unused -e OPENID_ISSUER_URL=unused -e OPENID_CLIENT_ID=unused -e OPENID_CLIENT_SECRET=unused --method tools/list",
         env!("CARGO_BIN_EXE_stdio")
     );
     log::debug!("inspector command: {}", inspector_commmand);
     let output = Command::new("sh")
         .arg("-c")
         .arg(inspector_commmand)
-        .env("API_URL", "")
-        .env("OPENID_ISSUER_URL", "")
-        .env("OPENID_CLIENT_ID", "")
-        .env("OPENID_CLIENT_SECRET", "")
         .output()
         .expect("failed to execute process");
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -337,7 +337,10 @@ async fn tools_list_mcp_client() -> Result<(), Error> {
     // Initialize
     let server_info = service.peer_info();
     log::debug!("Connected to server: {server_info:#?}");
-    assert_eq!(server_info.unwrap().server_info.name, "mcp-stdio");
+    assert_eq!(
+        server_info.unwrap().server_info.as_ref().unwrap().name,
+        "mcp-stdio"
+    );
 
     // List tools
     let tools = service.list_all_tools().await?;


### PR DESCRIPTION
## Summary by Sourcery

Upgrade rmcp dependency to version 3.0.0 and adjust integration tests for the updated server info API.

Enhancements:
- Update runtime and dev rmcp dependencies from 2.2.0 to 3.0.0 to adopt the latest API.
- Adapt server info assertions in the integration test to the new rmcp server_info structure.