### PR TITLE
chore: update rmcp v3.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4795,9 +4795,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "3.0.1"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3797d226787327b35b0b6f9e878fe55f3af2bb4daf916c0411079885454042f0"
+checksum = "ad26b216c966e987e80e86daf784a455c039c43d98575ceed57b8faa259e5695"
 dependencies = [
  "async-trait",
  "base64 0.23.0",
@@ -4827,9 +4827,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "3.0.1"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f5bc0c6851a20cd627ef4b90defb79f39a261c467de52af5d38000d7979c52"
+checksum = "41bc748630c2be2a71b614c2f40d27bc0df0060696d224e1692c72345b7e0b79"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ axum = { version = "0.8", features = ["macros"] }
 chrono = "0.4"
 openid = "0.18.0"
 reqwest = { version = "0.12", features = ["json", "blocking"] }
-rmcp = { version = "3.0.1", features = ["server", "transport-io", "transport-streamable-http-server"] }
+rmcp = { version = "3.1.0", features = ["server", "transport-io", "transport-streamable-http-server"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "io-std", "signal"] }
@@ -33,6 +33,6 @@ urlencoding = "2.1"
 
 [dev-dependencies]
 log = "0.4"
-rmcp = { version = "3.0.1", features = ["client", "transport-child-process"] }
+rmcp = { version = "3.1.0", features = ["client", "transport-child-process"] }
 test-log = "0.2.18"
 trustify-test-context = { git = "https://github.com/guacsec/trustify.git", tag = "v0.4.5"}


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Bump rmcp crate version from 3.0.1 to 3.1.0 in production and dev dependency configurations.